### PR TITLE
fix: configure Netlify to ignore expected NEXT_PUBLIC_ variables in s…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,30 @@
+[build]
+  command = "npm run build"
+  publish = ".next"
+
+[build.environment]
+  # Disable secrets scanning for expected NEXT_PUBLIC_ variables
+  SECRETS_SCAN_OMIT_KEYS = "NEXT_PUBLIC_STRAPI_API_URL,NEXT_PUBLIC_EMAILJS_SERVICE_ID,NEXT_PUBLIC_EMAILJS_TEMPLATE_ID,NEXT_PUBLIC_EMAILJS_PUBLIC_KEY"
+
+# Next.js specific configuration
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
+
+# Cache optimization
+[[headers]]
+  for = "/_next/static/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Image optimization redirects
+[[redirects]]
+  from = "/_next/image"
+  to = "/.netlify/images?url=:url&w=:width&q=:quality"
+  status = 200
+  query = {q = ":quality", url = ":url", w = ":width"}
+
+[[redirects]]
+  from = "/_ipx/*"
+  to = "/.netlify/images?url=:url&w=:width&q=:quality"
+  status = 200
+  query = {q = ":quality", url = ":url", w = ":width"}


### PR DESCRIPTION
…ecrets scan

- Add netlify.toml with SECRETS_SCAN_OMIT_KEYS configuration
- NEXT_PUBLIC_ variables are expected to be in client bundle
- Configure Next.js plugin and optimization settings