### PR TITLE
fix: resolve Next.js 15 dynamic import compatibility issues

### DIFF
--- a/src/components/AIChatWidget.tsx
+++ b/src/components/AIChatWidget.tsx
@@ -10,7 +10,7 @@ import type { Message, ErrorResponse, ChatOK } from '@/types';
 import { Button, Input, GlassCard } from '@/ui';
 import { useToast } from '@/ui/use-toast';
 
-export const AIChatWidget: React.FC = () => {
+const AIChatWidget: React.FC = () => {
   const { isOpen, toggleModal } = useChatWidget();
   const [messages, setMessages] = useState<Message[]>([
     {
@@ -325,3 +325,5 @@ export const AIChatWidget: React.FC = () => {
     </>
   );
 };
+
+export default AIChatWidget;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,12 +21,10 @@ import type {
   AdditionalProject,
 } from '@/types';
 
-const AIChatWidget = dynamic(
-  () => import('@/components/AIChatWidget').then((mod) => mod.AIChatWidget),
-  {
-    ssr: false,
-  }
-);
+const AIChatWidget = dynamic(() => import('@/components/AIChatWidget'), {
+  ssr: false,
+  loading: () => null,
+});
 
 interface Props {
   profile?: ProcessedProfile;

--- a/src/ui/image-carousel.tsx
+++ b/src/ui/image-carousel.tsx
@@ -6,9 +6,7 @@ import type { ImageObj } from '@/ui/image-modal';
 import { ImageWithFallback } from '@/ui/image-with-fallback';
 
 // Dynamically import ImageModal to reduce initial bundle size
-const ImageModal = lazy(() =>
-  import('@/ui/image-modal').then((mod) => ({ default: mod.ImageModal }))
-);
+const ImageModal = lazy(() => import('@/ui/image-modal'));
 
 export interface ImageCarouselProps {
   images: ImageObj[];


### PR DESCRIPTION
- Update AIChatWidget to use default export instead of named export
- Fix dynamic import syntax to be compatible with Next.js 15
- Update ImageCarousel dynamic import for ImageModal
- Resolves 'Cannot read properties of undefined (reading getInitialProps)' error