### PR TITLE
fix: remove 'use client' directives causing getInitialProps error

### DIFF
--- a/src/components/AIChatWidget.tsx
+++ b/src/components/AIChatWidget.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { MessageCircle, X, Send } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,8 +2,7 @@ import { GetStaticProps } from 'next';
 import Head from 'next/head';
 import { useState } from 'react';
 
-import dynamic from 'next/dynamic';
-
+import AIChatWidget from '@/components/AIChatWidget';
 import Footer from '@/components/Footer';
 import Navigation from '@/components/Navigation';
 import ResumeModal from '@/components/ResumeModal';
@@ -21,14 +20,6 @@ import type {
   ProcessedContactMethod,
   AdditionalProject,
 } from '@/types';
-
-const AIChatWidget = dynamic(
-  () => import('@/components/AIChatWidget').catch(() => ({ default: () => null })),
-  {
-    ssr: false,
-    loading: () => null,
-  }
-);
 
 interface Props {
   profile?: ProcessedProfile;

--- a/src/ui/error-boundary.tsx
+++ b/src/ui/error-boundary.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 
 import { clientEnv } from '@/lib/env';

--- a/src/ui/image-carousel.tsx
+++ b/src/ui/image-carousel.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { useState } from 'react';
 
 import ImageModal from '@/ui/image-modal';

--- a/src/ui/image-modal.tsx
+++ b/src/ui/image-modal.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/src/ui/image-with-fallback.tsx
+++ b/src/ui/image-with-fallback.tsx
@@ -1,13 +1,11 @@
-"use client";
-
-import { RefreshCw } from "lucide-react";
-import Image, { ImageProps } from "next/image";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { RefreshCw } from 'lucide-react';
+import Image, { ImageProps } from 'next/image';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 // If you don't have a cn util, replace cn(...) with a simple template string
-import { cn } from "@/lib";
+import { cn } from '@/lib';
 
-type Props = Omit<ImageProps, "alt" | "quality" | "onLoadingComplete"> & {
+type Props = Omit<ImageProps, 'alt' | 'quality' | 'onLoadingComplete'> & {
   alt: string;
   /** ms before we consider it “too slow” and show a fallback */
   timeoutMs?: number;
@@ -18,13 +16,13 @@ type Props = Omit<ImageProps, "alt" | "quality" | "onLoadingComplete"> & {
 };
 
 const DEFAULT_BLUR =
-  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjUwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9IiMyMjIyMjIiLz48L3N2Zz4=";
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwIiBoZWlnaHQ9IjUwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9IiMyMjIyMjIiLz48L3N2Zz4=';
 
 export function ImageWithFallback({
   timeoutMs = 8000,
   fallback,
   skeletonClassName,
-  placeholder = "blur",
+  placeholder = 'blur',
   blurDataURL = DEFAULT_BLUR,
   fetchPriority,
   priority,
@@ -78,18 +76,14 @@ export function ImageWithFallback({
   );
 
   return (
-    <div
-      className={cn("relative", className)}
-      aria-busy={!loaded}
-      aria-live="polite"
-    >
+    <div className={cn('relative', className)} aria-busy={!loaded} aria-live="polite">
       {!showFallback && (
         <>
           {/* Skeleton while loading */}
           {!loaded && (
             <div
               className={cn(
-                "absolute inset-0 animate-pulse rounded-lg bg-muted/30",
+                'absolute inset-0 animate-pulse rounded-lg bg-muted/30',
                 skeletonClassName
               )}
             />
@@ -106,7 +100,7 @@ export function ImageWithFallback({
             onLoad={() => setLoaded(true)} // <- use onLoad (no deprecation)
             onError={() => setErrored(true)}
             // Hide until loaded to avoid flash/jank
-            style={{ visibility: loaded ? "visible" : "hidden", ...style }}
+            style={{ visibility: loaded ? 'visible' : 'hidden', ...style }}
           />
         </>
       )}


### PR DESCRIPTION
- Remove all 'use client' directives from components (App Router syntax)
- Fix import order and remove empty lines to resolve linting warnings
- Remove dynamic import for AIChatWidget, use regular import
- Clear Next.js build cache for clean build
- This resolves the Pages Router vs App Router conflict in Next.js 15